### PR TITLE
use secure links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 *.out
 *.eps
 *.pdf
+*.fls
+*.fdb_latexmk

--- a/dissdefs.tex
+++ b/dissdefs.tex
@@ -45,9 +45,9 @@
 \definecolor{rltred}{rgb}{0.4,0,0}
 \definecolor{rltgreen}{rgb}{0,0.5,0}
 \definecolor{rltblue}{rgb}{0,0,0.5}
-\newcommand{\datalink}[2]{\href{http://wuerl.net/diss/microwave/#1}{#2}}
-\newcommand{\plotlink}[2]{\href{http://wuerl.net/diss/gp/#1.gp}{#2}}
-\newcommand{\link}[1]{\href{http://#1}{#1}}
+\newcommand{\datalink}[2]{\href{https://wuerl.net/diss/microwave/#1}{#2}}
+\newcommand{\plotlink}[2]{\href{https://wuerl.net/diss/gp/#1.gp}{#2}}
+\newcommand{\link}[1]{\href{https://#1}{#1}}
   
 \bibliographystyle{leidiss}
 

--- a/dvddissdefs.tex
+++ b/dvddissdefs.tex
@@ -43,9 +43,9 @@
 	\definecolor{rltred}{rgb}{0.4,0,0}
 	\definecolor{rltgreen}{rgb}{0,0.5,0}
 	\definecolor{rltblue}{rgb}{0,0,0.5}
-	\newcommand{\datalink}[2]{\href{http://wuerl.net/diss/microwave/#1}{#2}}
-	\newcommand{\plotlink}[2]{\href{http://wuerl.net/diss.html/#1.gp}{#2}}
-	\newcommand{\link}[1]{\href{http://#1}{#1}}
+	\newcommand{\datalink}[2]{\href{https://wuerl.net/diss/microwave/#1}{#2}}
+	\newcommand{\plotlink}[2]{\href{https://wuerl.net/diss.html/#1.gp}{#2}}
+	\newcommand{\link}[1]{\href{https://#1}{#1}}
 \else
 	\newcommand{\datalink}[2]{#2}
 	\newcommand{\plotlink}[2]{#2}


### PR DESCRIPTION
We should use `https` instead of `http` when linking information.